### PR TITLE
GCI 2018: Added notification at the end of the call to save the number

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     package="com.community.jboss.leadmanagement">
 
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG" />
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_CONTACTS" />
     <uses-permission android:name="android.permission.CALL_PHONE" />
@@ -43,9 +44,11 @@
             android:enabled="true"
             android:exported="true">
             <intent-filter>
+                <action android:name="android.intent.action.NEW_OUTGOING_CALL"/>
                 <action android:name="android.intent.action.PHONE_STATE" />
             </intent-filter>
         </receiver>
+
 
         <activity
             android:name=".SettingsActivity"

--- a/app/src/main/java/com/community/jboss/leadmanagement/CallReceiver.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/CallReceiver.java
@@ -16,6 +16,8 @@ import com.community.jboss.leadmanagement.main.contacts.editcontact.EditContactA
 
 public class CallReceiver extends BroadcastReceiver {
     private static final int ID = 47981;
+    private static final int STATE_DURING_CALL = 1;
+    private static final int STATE_AFTER_CALL = 2;
 
     private String number;
     private Context mContext;
@@ -39,53 +41,64 @@ public class CallReceiver extends BroadcastReceiver {
         this.number = callerNum;
 
         if (state.equals(TelephonyManager.EXTRA_STATE_RINGING)) {
-            showNotification();
-        } else if (state.equals(TelephonyManager.EXTRA_STATE_IDLE)) {
+            showNotification(STATE_DURING_CALL, number);
+        }else if (state.equals(TelephonyManager.EXTRA_STATE_IDLE)) {
             hideNotification();
+            showNotification(STATE_AFTER_CALL, number);
         } else if (state.equals(TelephonyManager.EXTRA_STATE_OFFHOOK)) {
-            showNotification();
+            showNotification(STATE_DURING_CALL, number);
         }
     }
 
-    private void hideNotification() {
-        final NotificationManager manager =
-                (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (manager != null) {
-            manager.cancel(ID);
-        }
-    }
-
-    private void showNotification() {
-
-        final Intent notificationIntent = new Intent(mContext, EditContactActivity.class);
-        String CHANNEL_ID = "lead-management-ch";
-
-        notificationIntent.putExtra(
-                EditContactActivity.INTENT_EXTRA_CONTACT_NUM, number);
-
-        final PendingIntent contentIntent = PendingIntent.getActivity(mContext, 0,
-                notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-
-        final NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext)
-                .setSmallIcon(R.drawable.ic_call_black_24dp)
-                .setContentTitle("Call in Progress")
-                .setTicker("Lead Management")
-                .setContentIntent(contentIntent)
-                .setContentText("Number: " + number)
-                .setChannelId(CHANNEL_ID);
-
-        final NotificationManager manager =
-                (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-        if (manager != null) {
-            manager.cancel(ID);
-            // check build version
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                CharSequence name = "Lead-Management-Channel";
-                int importance = NotificationManager.IMPORTANCE_HIGH;
-                NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, name, importance);
-                manager.createNotificationChannel(mChannel);
+        private void hideNotification() {
+            final NotificationManager manager =
+                    (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (manager != null) {
+                manager.cancel(ID);
             }
-            manager.notify(ID, notification.build());
         }
-    }
+
+        private void showNotification(int callState, String number) {
+            final Intent notificationIntent = new Intent(mContext, EditContactActivity.class);
+            String CHANNEL_ID = "lead-management-ch";
+
+            notificationIntent.putExtra(EditContactActivity.INTENT_EXTRA_CONTACT_NUM, number);
+
+            final PendingIntent contentIntent = PendingIntent.getActivity(mContext, 0,
+                    notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+            final NotificationCompat.Builder notification;
+            if (callState == STATE_DURING_CALL) {
+                notification = new NotificationCompat.Builder(mContext, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_call_black_24dp)
+                        .setContentTitle("Call in Progress")
+                        .setTicker("Lead Management")
+                        .setContentIntent(contentIntent)
+                        .setContentText("Number: " + number);
+            } else {
+                String fullText = "Do you want to save what you discussed with this Client?\nNumber: " + number;
+                notification = new NotificationCompat.Builder(mContext, CHANNEL_ID)
+                        .setSmallIcon(R.drawable.ic_call_black_24dp)
+                        .setContentTitle("Call finished")
+                        .setStyle(new NotificationCompat.BigTextStyle().bigText(fullText))
+                        .setContentText(fullText)
+                        .setAutoCancel(true)
+                        .setTicker("Lead Management")
+                        .addAction(0, "Yes", contentIntent)
+                        .setContentIntent(contentIntent);
+            }
+            final NotificationManager manager =
+                    (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (manager != null) {
+                manager.cancel(ID);
+                // check build version
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    CharSequence name = "Lead-Management-Channel";
+                    int importance = NotificationManager.IMPORTANCE_HIGH;
+                    NotificationChannel mChannel = new NotificationChannel(CHANNEL_ID, name, importance);
+                    manager.createNotificationChannel(mChannel);
+                }
+                manager.notify(ID, notification.build());
+            }
+        }
 }

--- a/app/src/main/java/com/community/jboss/leadmanagement/data/LeadDatabase.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/data/LeadDatabase.java
@@ -1,9 +1,12 @@
 package com.community.jboss.leadmanagement.data;
 
+import android.arch.persistence.db.SupportSQLiteDatabase;
 import android.arch.persistence.room.Database;
 import android.arch.persistence.room.Room;
 import android.arch.persistence.room.RoomDatabase;
+import android.arch.persistence.room.migration.Migration;
 import android.content.Context;
+import android.support.annotation.NonNull;
 
 import com.community.jboss.leadmanagement.data.daos.ContactDao;
 import com.community.jboss.leadmanagement.data.daos.ContactNumberDao;
@@ -19,20 +22,31 @@ import com.community.jboss.leadmanagement.data.entities.Tag;
         ContactNumber.class,
         Tag.class,
         ContactTagJoin.class,
-}, version = 1, exportSchema = false)
+}, version = 2, exportSchema = false)
 public abstract class LeadDatabase extends RoomDatabase {
     private static final String DATABASE_NAME = "leadmanagement.db";
 
     private static volatile LeadDatabase sInstance;
 
     public static synchronized LeadDatabase getInstance(Context context) {
+        final Migration migrationNewStructure = new Migration(1,2) {
+            @Override
+            public void migrate(@NonNull SupportSQLiteDatabase db) {
+                db.execSQL(
+                        "CREATE TABLE contact_new ('id' TEXT NOT NULL, 'name' TEXT, 'email' TEXT, 'query' TEXT, 'address' TEXT, 'callNotes' TEXT, 'photoBytes' BLOB, PRIMARY KEY(id))");
+                db.execSQL(
+                        "INSERT INTO contact_new (id, name) SELECT id, name FROM contact");
+                db.execSQL("DROP TABLE contact");
+                db.execSQL("ALTER TABLE contact_new RENAME TO contact");
+            }
+        };
         if (sInstance == null) {
             sInstance = Room.databaseBuilder(
                     context.getApplicationContext(),
                     LeadDatabase.class,
                     DATABASE_NAME
                     // TODO: Disallow main thread queries
-            ).allowMainThreadQueries().build();
+            ).addMigrations(migrationNewStructure).allowMainThreadQueries().build();
         }
         return sInstance;
     }

--- a/app/src/main/java/com/community/jboss/leadmanagement/data/entities/Contact.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/data/entities/Contact.java
@@ -15,6 +15,12 @@ public class Contact {
     @PrimaryKey @NonNull
     private final String id;
     private String name;
+    private String number;
+    private String email;
+    private String query;
+    private String address;
+    private String callNotes;
+    private byte[] photoBytes;
 
     @Ignore
     public Contact(String name) {
@@ -37,5 +43,52 @@ public class Contact {
 
     public void setName(String name) {
         this.name = name;
+    }
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getCallNotes() {
+        return callNotes;
+    }
+
+    public void setCallNotes(String callNotes) {
+        this.callNotes = callNotes;
+    }
+
+    public byte[] getPhotoBytes() {
+        return photoBytes;
+    }
+
+    public void setPhotoBytes(byte[] photoBytes) {
+        this.photoBytes = photoBytes;
     }
 }

--- a/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
@@ -134,6 +134,9 @@ public class MainActivity extends BaseActivity
         if (!permissionManager.permissionStatus(Manifest.permission.READ_PHONE_STATE)) {
             permissionManager.requestPermission(ID, Manifest.permission.READ_PHONE_STATE);
         }
+        if (!permissionManager.permissionStatus(Manifest.permission.READ_CALL_LOG)) {
+            permissionManager.requestPermission(ID, Manifest.permission.READ_CALL_LOG);
+        }
 
         ButterKnife.bind(this);
         setSupportActionBar(toolbar);

--- a/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/editcontact/EditContactActivityViewModel.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/editcontact/EditContactActivityViewModel.java
@@ -64,15 +64,20 @@ public class EditContactActivityViewModel extends AndroidViewModel {
         return contactNumberDao.getContactNumber(number);
     }
 
-    public void saveContact(String name) {
+    public void saveContact(String name, String email, String query, String address, String callNotes, byte[] photoBytes) {
         final ContactDao dao = DbUtil.contactDao(getApplication());
 
         Contact contact = mContact.getValue();
-        if (contact == null) {
+        if (contact == null){
             contact = new Contact(name);
         } else {
             contact.setName(name);
         }
+        contact.setEmail(email);
+        contact.setQuery(query);
+        contact.setAddress(address);
+        contact.setCallNotes(callNotes);
+        contact.setPhotoBytes(photoBytes);
 
         if (mIsNewContact) {
             dao.insert(contact);

--- a/app/src/main/res/drawable/ic_address_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_address_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_email_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_email_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,4L4,4c-1.1,0 -1.99,0.9 -1.99,2L2,18c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2zM20,8l-8,5 -8,-5L4,6l8,5 8,-5v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_info_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_info_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-6h2v6zM13,9h-2L11,7h2v2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_live_help_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_live_help_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,2L5,2c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h4l3,3 3,-3h4c1.1,0 2,-0.9 2,-2L21,4c0,-1.1 -0.9,-2 -2,-2zM13,18h-2v-2h2v2zM15.07,10.25l-0.9,0.92C13.45,11.9 13,12.5 13,14h-2v-0.5c0,-1.1 0.45,-2.1 1.17,-2.83l1.24,-1.26c0.37,-0.36 0.59,-0.86 0.59,-1.41 0,-1.1 -0.9,-2 -2,-2s-2,0.9 -2,2L8,8c0,-2.21 1.79,-4 4,-4s4,1.79 4,4c0,0.88 -0.36,1.68 -0.93,2.25z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_person_avatar.xml
+++ b/app/src/main/res/drawable/ic_person_avatar.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="120dp"
+        android:height="120dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,5c1.66,0 3,1.34 3,3s-1.34,3 -3,3 -3,-1.34 -3,-3 1.34,-3 3,-3zM12,19.2c-2.5,0 -4.71,-1.28 -6,-3.22 0.03,-1.99 4,-3.08 6,-3.08 1.99,0 5.97,1.09 6,3.08 -1.29,1.94 -3.5,3.22 -6,3.22z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_photo_camera_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_photo_camera_black_24dp.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,12m-3.2,0a3.2,3.2 0,1 1,6.4 0a3.2,3.2 0,1 1,-6.4 0"/>
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9,2L7.17,4L4,4c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2L22,6c0,-1.1 -0.9,-2 -2,-2h-3.17L15,2L9,2zM12,17c-2.76,0 -5,-2.24 -5,-5s2.24,-5 5,-5 5,2.24 5,5 -2.24,5 -5,5z"/>
+</vector>

--- a/app/src/main/res/layout/create_contact.xml
+++ b/app/src/main/res/layout/create_contact.xml
@@ -25,6 +25,27 @@
         android:orientation="vertical"
         android:padding="@dimen/activity_horizontal_margin">
 
+        <FrameLayout
+            android:layout_gravity="center"
+            android:layout_width="120dp"
+            android:layout_height="120dp"
+            android:layout_marginBottom="10dp">
+            <com.mikhaellopez.circularimageview.CircularImageView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:src="@drawable/ic_person_avatar"
+                android:tint="@android:color/darker_gray"
+                android:id="@+id/contact_photo"/>
+            <android.support.design.widget.FloatingActionButton
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/contact_select_photo"
+                android:layout_margin="6dp"
+                app:fabSize="mini"
+                android:src="@drawable/ic_photo_camera_black_24dp"
+                android:tint="@android:color/white"
+                android:layout_gravity="bottom|end"/>
+        </FrameLayout>
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -36,19 +57,23 @@
                 android:layout_height="30dp"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"
                 android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:src="@drawable/ic_person_grey_24dp" />
+                android:src="@drawable/ic_person_grey_24dp"
+                android:tint="@android:color/darker_gray" />
 
-            <EditText
-                android:id="@+id/contact_name_field"
+            <android.support.design.widget.TextInputLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/activity_horizontal_margin"
                 android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:hint="@string/name"
-                android:inputType="text" />
+                android:hint="@string/name" >
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_name_field"
+                    android:inputType="textCapWords"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </android.support.design.widget.TextInputLayout>
 
         </LinearLayout>
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -61,20 +86,142 @@
                 android:layout_height="30dp"
                 android:layout_marginEnd="@dimen/activity_horizontal_margin"
                 android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:src="@drawable/ic_phone_grey_24dp" />
+                android:src="@drawable/ic_phone_grey_24dp"
+                android:tint="@android:color/darker_gray" />
 
-            <EditText
-                android:id="@+id/contact_number_field"
+            <android.support.design.widget.TextInputLayout
                 android:maxLength="13"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="@dimen/activity_horizontal_margin"
                 android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:hint="@string/phone"
-                android:inputType="number" />
+                android:hint="@string/phone" >
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_number_field"
+                    android:inputType="phone"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </android.support.design.widget.TextInputLayout>
 
         </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/edittext_vertical_spacing"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
 
+            <ImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:src="@drawable/ic_email_black_24dp"
+                android:tint="@android:color/darker_gray" />
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:hint="@string/email">
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_email_field"
+                    android:inputType="textWebEmailAddress"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </android.support.design.widget.TextInputLayout>
+
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/edittext_vertical_spacing"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:src="@drawable/ic_live_help_black_24dp"
+                android:tint="@android:color/darker_gray" />
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:hint="@string/query">
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_query_field"
+                    android:inputType="textCapSentences"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </android.support.design.widget.TextInputLayout>
+
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/edittext_vertical_spacing"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:src="@drawable/ic_address_black_24dp"
+                android:tint="@android:color/darker_gray"/>
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:hint="@string/address" >
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_address_field"
+                    android:inputType="textPostalAddress"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </android.support.design.widget.TextInputLayout>
+
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/edittext_vertical_spacing"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:src="@drawable/ic_info_black_24dp"
+                android:tint="@android:color/darker_gray" />
+
+            <android.support.design.widget.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:hint="@string/call_notes" >
+                <android.support.design.widget.TextInputEditText
+                    android:id="@+id/contact_call_notes_field"
+                    android:inputType="textCapSentences"
+                    android:singleLine="false"
+                    android:maxLines="5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </android.support.design.widget.TextInputLayout>
+
+        </LinearLayout>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/popup_detail.xml
+++ b/app/src/main/res/layout/popup_detail.xml
@@ -27,10 +27,11 @@
         android:orientation="vertical">
 
         <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="@dimen/popup_contact_photo_size"
+            android:layout_height="@dimen/popup_contact_photo_size"
             android:layout_gravity="center"
-            android:src="@drawable/ic_person_grey" />
+            android:src="@drawable/ic_person_grey"
+            android:id="@+id/popupPhoto"/>
 
         <android.support.v7.widget.CardView
             android:layout_width="match_parent"
@@ -110,103 +111,252 @@
                             android:backgroundTint="@color/colorAccent" />
 
                     </LinearLayout>
-
-
                 </LinearLayout>
 
-
-                <LinearLayout
+                <ScrollView
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginLeft="15dp"
-                    android:layout_marginStart="15dp"
-                    android:orientation="vertical">
-
+                    android:layout_height="match_parent">
                     <LinearLayout
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:src="@drawable/ic_phone_grey_24dp" />
-
-
-                        <TextView
-                            android:id="@+id/txt_num"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_marginLeft="20dp"
-                            android:layout_marginStart="20dp"
-                            android:text="+91 1231231231"
-                            android:textColor="@android:color/black"
-                            android:textSize="17sp" />
-
-                    </LinearLayout>
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="45dp"
-                        android:layout_marginStart="45dp"
-                        android:text="@string/mobile" />
-
-                    <View
                         android:layout_width="match_parent"
-                        android:layout_height="1dp"
-                        android:layout_marginLeft="45dp"
-                        android:layout_marginStart="45dp"
-                        android:layout_marginTop="10dp"
-                        android:background="@android:color/darker_gray" />
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="10dp"
-                    android:layout_marginLeft="15dp"
-                    android:layout_marginStart="15dp"
-                    android:orientation="vertical">
-
-                    <LinearLayout
-                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:layout_width="24dp"
-                            android:layout_height="24dp"
-                            android:layout_marginTop="1dp"
-                            android:src="@drawable/ic_email"
-                            android:tint="@android:color/darker_gray" />
-
-
-                        <TextView
-                            android:layout_width="wrap_content"
+                        android:orientation="vertical">
+                        <LinearLayout
+                            android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:layout_marginLeft="20dp"
-                            android:layout_marginStart="20dp"
-                            android:text="sabaxuxunashvili@gmail.com"
-                            android:textColor="@android:color/black"
-                            android:textSize="17sp"
-                            android:id="@+id/popupMail"/>
+                            android:layout_marginTop="10dp"
+                            android:layout_marginLeft="15dp"
+                            android:layout_marginStart="15dp"
+                            android:orientation="vertical">
 
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="@dimen/popup_square_icon_size"
+                                    android:layout_height="@dimen/popup_square_icon_size"
+                                    android:src="@drawable/ic_phone_grey_24dp" />
+
+
+                                <TextView
+                                    android:id="@+id/txt_num"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="20dp"
+                                    android:layout_marginStart="20dp"
+                                    android:text="+91 1231231231"
+                                    android:textColor="@android:color/black"
+                                    android:textSize="17sp" />
+
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:text="@string/mobile" />
+
+                            <View
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:layout_marginTop="10dp"
+                                android:background="@android:color/darker_gray" />
+
+                        </LinearLayout>
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            android:layout_marginLeft="15dp"
+                            android:layout_marginStart="15dp"
+                            android:orientation="vertical">
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="@dimen/popup_square_icon_size"
+                                    android:layout_height="@dimen/popup_square_icon_size"
+                                    android:layout_marginTop="1dp"
+                                    android:src="@drawable/ic_email"
+                                    android:tint="@android:color/darker_gray" />
+
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="20dp"
+                                    android:layout_marginStart="20dp"
+                                    android:text="sabaxuxunashvili@gmail.com"
+                                    android:textColor="@android:color/black"
+                                    android:textSize="17sp"
+                                    android:id="@+id/popupMail"/>
+
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:text="@string/email" />
+                            <View
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:layout_marginTop="10dp"
+                                android:background="@android:color/darker_gray" />
+                        </LinearLayout>
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            android:layout_marginLeft="15dp"
+                            android:layout_marginStart="15dp"
+                            android:orientation="vertical">
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="@dimen/popup_square_icon_size"
+                                    android:layout_height="@dimen/popup_square_icon_size"
+                                    android:layout_marginTop="1dp"
+                                    android:src="@drawable/ic_live_help_black_24dp"
+                                    android:tint="@android:color/darker_gray" />
+
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="20dp"
+                                    android:layout_marginStart="20dp"
+                                    android:text="this is a query"
+                                    android:textColor="@android:color/black"
+                                    android:textSize="17sp"
+                                    android:id="@+id/popupQuery"/>
+
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:text="@string/query" />
+                            <View
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:layout_marginTop="10dp"
+                                android:background="@android:color/darker_gray" />
+                        </LinearLayout>
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            android:layout_marginLeft="15dp"
+                            android:layout_marginStart="15dp"
+                            android:orientation="vertical">
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="24dp"
+                                    android:layout_height="24dp"
+                                    android:layout_marginTop="1dp"
+                                    android:src="@drawable/ic_address_black_24dp"
+                                    android:tint="@android:color/darker_gray" />
+
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="20dp"
+                                    android:layout_marginStart="20dp"
+                                    android:text="Madrid"
+                                    android:textColor="@android:color/black"
+                                    android:textSize="17sp"
+                                    android:id="@+id/popupAddress"/>
+
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:text="@string/address" />
+                            <View
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:layout_marginTop="10dp"
+                                android:background="@android:color/darker_gray" />
+                        </LinearLayout>
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="10dp"
+                            android:layout_marginLeft="15dp"
+                            android:layout_marginStart="15dp"
+                            android:orientation="vertical">
+
+                            <LinearLayout
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:orientation="horizontal">
+
+                                <ImageView
+                                    android:layout_width="24dp"
+                                    android:layout_height="24dp"
+                                    android:layout_marginTop="1dp"
+                                    android:src="@drawable/ic_info_black_24dp"
+                                    android:tint="@android:color/darker_gray" />
+
+
+                                <TextView
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginLeft="20dp"
+                                    android:layout_marginStart="20dp"
+                                    android:text="This call was short and concise"
+                                    android:textColor="@android:color/black"
+                                    android:textSize="17sp"
+                                    android:id="@+id/popupCallNotes"/>
+
+                            </LinearLayout>
+
+                            <TextView
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:text="@string/call_notes" />
+                            <View
+                                android:layout_width="match_parent"
+                                android:layout_height="1dp"
+                                android:layout_marginLeft="45dp"
+                                android:layout_marginStart="45dp"
+                                android:layout_marginTop="10dp"
+                                android:background="@android:color/darker_gray" />
+                        </LinearLayout>
                     </LinearLayout>
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="45dp"
-                        android:layout_marginStart="45dp"
-                        android:text="@string/email" />
-
-
-
-                </LinearLayout>
-
+                </ScrollView>
 
             </LinearLayout>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -6,4 +6,6 @@
     <dimen name="nav_header_height">176dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
     <dimen name="edittext_vertical_spacing">8dp</dimen>
+    <dimen name="popup_square_icon_size">24dp</dimen>
+    <dimen name="popup_contact_photo_size">140dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,9 @@
     <string name="title_groups">Groups</string>
     <string name="name">Name</string>
     <string name="phone">Phone</string>
+    <string name="address">Address</string>
+    <string name="call_notes">Call notes</string>
+    <string name="query">Query</string>
 
 
     <string name="title_add_contact">Add Contact</string>


### PR DESCRIPTION
This is part of the Google Code-in contest 2018. [See task.](https://codein.withgoogle.com/tasks/6070718732173312)

Added a new notification which appears on screen when the user hangs up a call, and suggests to save the other person's number.
Another notification shows up when the user is receiving a call or participating in it.

This PR also includes the previous requirement for this task: 

> Implemented changes in the SQLite database adapter and in the `Contact` class. Created and modified methods in order to save all the fields in the contact object correctly, including the photo.
Changes in the Edit/Add contact layout in order to reflect all contact fields. Edited the contact info popup to display all the information (added `ScrollView`) necessary. If there is an empty field, that information is not shown.

Fixes #131 

Tested on Android Emulator API 28 (Android 9.0 Pie) and Motorola Moto E5 4G 2015 (API 21, 5.0.2 Lollipop).

Some GIFs to show the behaviour:

![lmnotification](https://user-images.githubusercontent.com/20025623/47670313-21eff800-dbad-11e8-95bf-3b23db421b31.gif)
![lmnotification2](https://user-images.githubusercontent.com/20025623/47670314-22888e80-dbad-11e8-9a7a-a844ef1b2130.gif)
