### PR TITLE
#277 | GCI 2018 Remove "Toggle Theme mode" from side navigation drawer.

### DIFF
--- a/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
@@ -91,8 +91,6 @@ public class MainActivity extends BaseActivity
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        visibleBtn(useDarkTheme);
-
         mViewModel = ViewModelProviders.of(this).get(MainActivityViewModel.class);
 
         mViewModel.getSelectedNavItem().observe(this, this::displayNavigationItem);
@@ -211,14 +209,6 @@ public class MainActivity extends BaseActivity
             case R.id.nav_settings:
                 navigationItem = MainActivityViewModel.NavigationItem.SETTINGS;
                 break;
-            case R.id.toggle_theme:
-                darkTheme(true);
-                navigationItem = MainActivityViewModel.NavigationItem.CONTACTS;
-                break;
-            case R.id.light_theme:
-                darkTheme(false);
-                navigationItem = MainActivityViewModel.NavigationItem.CONTACTS;
-                break;
             default:
                 Timber.e("Failed to resolve selected navigation item id");
                 throw new IllegalArgumentException();
@@ -243,12 +233,6 @@ public class MainActivity extends BaseActivity
             case SETTINGS:
                 startActivity(new Intent(this, SettingsActivity.class));
                 return;
-            case TOGGLE_THEME:
-                darkTheme(true);
-
-                return;
-            case LIGHT_THEME:
-                darkTheme(false);
             default:
                 Timber.e("Failed to resolve selected NavigationItem");
                 throw new IllegalArgumentException();
@@ -385,33 +369,6 @@ public class MainActivity extends BaseActivity
         if (fragment instanceof ContactsFragment) {
             fab.setOnClickListener(view -> startActivity(new Intent(getApplicationContext(), EditContactActivity.class)));
             fab.setImageResource(R.drawable.ic_add_white_24dp);
-        }
-    }
-
-    private void darkTheme(boolean darkTheme) {
-        SharedPreferences.Editor editor = PreferenceManager.getDefaultSharedPreferences(this).edit();
-        editor.putBoolean(PREF_DARK_THEME, darkTheme);
-        editor.apply();
-
-        Intent intent = getIntent();
-        finish();
-
-        startActivity(intent);
-    }
-
-    private void visibleBtn(boolean darkTheme){
-        NavigationView navigationView = findViewById(R.id.nav_view);
-        Menu menu = navigationView.getMenu();
-        MenuItem darkBtn = menu.findItem(R.id.toggle_theme);
-        MenuItem lightBtn = menu.findItem(R.id.light_theme);
-
-        if (darkTheme){
-            darkBtn.setVisible(false);
-            lightBtn.setVisible(true);
-        }
-        else {
-            darkBtn.setVisible(true);
-            lightBtn.setVisible(false);
         }
     }
 

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -3,8 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:showIn="navigation_view">
 
-    <group android:checkableBehavior="single"
-        android:id="@+id/top_pane">
+    <group
+        android:id="@+id/top_pane"
+        android:checkableBehavior="single">
         <item
             android:id="@+id/nav_contacts"
             android:icon="@drawable/ic_menu_contacts"
@@ -15,20 +16,12 @@
             android:title="@string/title_groups" />
     </group>
 
-    <group android:checkableBehavior="none"
-        android:id="@+id/bottom_pane">
+    <group
+        android:id="@+id/bottom_pane"
+        android:checkableBehavior="none">
         <item
             android:id="@+id/nav_settings"
             android:icon="@drawable/ic_settings_black_24dp"
-            android:title="@string/action_settings"/>
-        <item
-            android:id="@+id/toggle_theme"
-            android:icon="@drawable/ic_night"
-            android:title="@string/toggle"/>
-
-        <item
-            android:id="@+id/light_theme"
-            android:icon="@drawable/ic_wb_sunny_black_24dp"
-            android:title="@string/toggle"/>
+            android:title="@string/action_settings" />
     </group>
 </menu>


### PR DESCRIPTION
Removed "Toggle Theme mode" from side navigation drawer.
Fix #277.

Screenshot:
![screenshot_1541800260](https://user-images.githubusercontent.com/34242059/48290031-c4dc2800-e471-11e8-94c6-42f13c0f0eff.png)
