### PR TITLE
Notifications to display call recording is in progress, Fixed Deprecated API's

### DIFF
--- a/app/src/main/java/com/community/jboss/leadmanagement/CallReceiver.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/CallReceiver.java
@@ -66,6 +66,7 @@ public class CallReceiver extends BroadcastReceiver {
         // Call Recording Service Intent
         Intent notifyIntent = new Intent("com.aykuttasil.callrecord.CallRecord");
         notifyIntent.setClass(mContext, CallRecorderService.class);
+        notifyIntent.putExtra("number",number);
 
         PendingIntent notifyPendingIntent = PendingIntent.getService(
                 mContext, 0, notifyIntent, 0
@@ -82,18 +83,7 @@ public class CallReceiver extends BroadcastReceiver {
                                 notifyPendingIntent);
 
 
-        // Contact Details Intent
-        Intent contentIntent = new Intent(mContext, EditContactActivity.class);
-        PendingIntent contentPendingIntent = PendingIntent.getActivity(mContext, 0, contentIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
 
-        final NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext)
-                .setSmallIcon(R.drawable.ic_phone)
-                .setContentTitle("Call in Progress")
-                .setTicker("Lead Management")
-                .setContentIntent(contentPendingIntent)
-                .setContentText("Number: " + number)
-                .setChannelId(CHANNEL_ID);
 
         NotificationManager mNotificationManager =
                 (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
@@ -110,4 +100,5 @@ public class CallReceiver extends BroadcastReceiver {
 
         }
     }
+
 }

--- a/app/src/main/java/com/community/jboss/leadmanagement/CallRecorderService.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/CallRecorderService.java
@@ -1,14 +1,21 @@
 package com.community.jboss.leadmanagement;
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
 import android.media.AudioManager;
 import android.media.MediaRecorder;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Environment;
 import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
 import android.widget.Toast;
+
+import com.community.jboss.leadmanagement.main.contacts.editcontact.EditContactActivity;
 
 import java.io.File;
 import java.io.IOException;
@@ -17,11 +24,11 @@ public class CallRecorderService extends Service {
 
     private final String AUDIO_RECORDER_FILE_EXT_MP4 = ".mp4";
     private final String AUDIO_RECORDER_FOLDER = "Lead Management Recordings";
-
+    private String CHANNEL_ID = "LEAD_MANAGEMENT_ID";
+    private int ID = 54321;
     private MediaRecorder recorder = null;
 
     AudioManager audioManager;
-
 
 
     @Nullable
@@ -32,8 +39,8 @@ public class CallRecorderService extends Service {
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        audioManager = (AudioManager)getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
-        if(audioManager != null) {
+        audioManager = (AudioManager) getApplicationContext().getSystemService(Context.AUDIO_SERVICE);
+        if (audioManager != null) {
             audioManager.setMode(AudioManager.MODE_IN_CALL);
             audioManager.setSpeakerphoneOn(true);
         }
@@ -52,9 +59,10 @@ public class CallRecorderService extends Service {
         } catch (IOException e) {
             e.printStackTrace();
         }
-
+        startRecording();
         Toast.makeText(this, "Started", Toast.LENGTH_SHORT).show();
         return super.onStartCommand(intent, flags, startId);
+
     }
 
     @Override
@@ -68,7 +76,7 @@ public class CallRecorderService extends Service {
 
                 recorder = null;
             }
-        }catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             Toast.makeText(this, e.getLocalizedMessage(), Toast.LENGTH_SHORT).show();
         }
     }
@@ -82,5 +90,34 @@ public class CallRecorderService extends Service {
         }
 
         return (file.getAbsolutePath() + "/" + System.currentTimeMillis() + AUDIO_RECORDER_FILE_EXT_MP4);
+    }
+
+    public void startRecording() {  // This functions updates the notification to show that Call recording is in process
+        Context mContext = getApplicationContext();
+        Intent contentIntent = new Intent(getApplicationContext(), EditContactActivity.class);
+        PendingIntent contentPendingIntent = PendingIntent.getActivity(mContext, 0, contentIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        final NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_phone)
+                .setContentTitle("Recording in Progress")
+                .setTicker("Lead Management")
+                .setContentIntent(contentPendingIntent)
+                .setChannelId(CHANNEL_ID)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT); // Necessary to allow support for Android 8.0 and Higher
+        NotificationManager mNotificationManager =
+                (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        if (mNotificationManager != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
+                        "This is a notification channel for displaying recording option.",
+                        NotificationManager.IMPORTANCE_DEFAULT);
+                mNotificationManager.createNotificationChannel(channel);
+            }
+
+            mNotificationManager.notify(ID, notification.build());
+
+        }
     }
 }


### PR DESCRIPTION
**Notifications -Lead Management Android**
 The apps notifications were missing some features so I have added them
- After user taps Record Now Button and the recording starts. The notification still remains the same so i have updated it to show the status  i.e "Call is recording" Upon Hanging Up the notification is Removed.

- I have also addressed some deprected API issues.

- I have also added support for Android 8.0 and above devices which require ``` setPriority(NotificationCompat.PRIORITY_DEFAULT) ``` to be set to work properly.


This Pull request addresses issue https://github.com/JBossOutreach/lead-management-android/issues/318  

