### PR TITLE
Added RegEx checks.

### DIFF
--- a/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/editcontact/EditContactActivity.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/contacts/editcontact/EditContactActivity.java
@@ -231,7 +231,7 @@ public class EditContactActivity extends AppCompatActivity {
         boolean status = true;
 
         if(checkEditText(emailField, "Please enter mail")){
-            if(!emailField.getText().toString().contains("@")){
+            if(!emailField.getText().toString().matches("([\\w]+[@][\\w]+[.][A-z]+)")){
                 emailField.setError("Wrong mail formatting");
                 status = false;
             }
@@ -241,7 +241,10 @@ public class EditContactActivity extends AppCompatActivity {
             status = false;
         }
         if(!checkEditText(contactNameField, "Please enter full name")){
-            status = false;
+            if(!contactNameField.getText().toString().matches("([\\w]|[\\s+])*")) {
+                contactNameField.setError("Can't contain special characters");
+                status = false;
+            }
         }
         if(!checkEditText(queryField, "Please enter query")){
             status = false;


### PR DESCRIPTION
## Before
- Emails such as `example@example` were accepted.
- Names such as `Example@#$` were accepted.
## After
- Emails are checked using a RegEx pattern and any entry not containing a domain provider will not be accepted, eg: `example@example.com` will be accepted.
- Names containing special characters are not accepted.