### PR TITLE
Upgraded not letting user sign in feature

### DIFF
--- a/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
+++ b/app/src/main/java/com/community/jboss/leadmanagement/main/MainActivity.java
@@ -10,10 +10,12 @@ import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
 import android.support.design.widget.BottomNavigationView;
 import android.support.design.widget.FloatingActionButton;
+import android.support.design.widget.Snackbar;
 import android.support.v4.app.Fragment;
 import android.support.v7.widget.Toolbar;
 import android.view.Menu;
 import android.view.MenuItem;
+import android.view.View;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
 
@@ -21,6 +23,7 @@ import com.community.jboss.leadmanagement.BaseActivity;
 import com.community.jboss.leadmanagement.PermissionManager;
 import com.community.jboss.leadmanagement.R;
 import com.community.jboss.leadmanagement.SettingsFragment;
+import com.community.jboss.leadmanagement.SignActivity;
 import com.community.jboss.leadmanagement.main.callrecord.CallRecordFragment;
 import com.community.jboss.leadmanagement.main.contacts.ContactsFragment;
 import com.community.jboss.leadmanagement.main.contacts.editcontact.EditContactActivity;
@@ -212,7 +215,14 @@ public class MainActivity extends BaseActivity
                 if(mAuth.getCurrentUser() != null) {
                     startActivity(new Intent(getApplicationContext(), EditContactActivity.class));
                 }else {
-                    Toast.makeText(this, R.string.not_signed, Toast.LENGTH_SHORT).show();
+                    Snackbar.make(view,R.string.not_signed, Snackbar.LENGTH_SHORT)
+                            .setAction(R.string.snackbar_text_sign, new View.OnClickListener() {
+                                @Override
+                                public void onClick(View view) {
+                                    Intent toSignInActivity = new Intent(MainActivity.this,SignActivity.class);
+                                    startActivity(toSignInActivity);
+                                }
+                            }).show();
                 }
             });
             fab.setImageResource(R.drawable.ic_add_white_24dp);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,4 +96,5 @@
     <string name="add_contact">Add contact</string>
     <string name="not_signed">Please, sign in first…</string>
     <string name="title_callrecordings">Recorded Calls</string>
+    <string name="snackbar_text_sign">Sign in</string>
 </resources>


### PR DESCRIPTION
In this pull request:
- I improved the previous work of @Khukhuna by creating a toast that automatically redirects the user to the sign in activity and that will make the sign in waaay easyer. the preview will be right under this.
- All the texts were also stored as string values
 
Before
------------------------------
![video2gif_20181216_112752](https://user-images.githubusercontent.com/38397893/50052547-14270f80-0126-11e9-9044-461115dab48e.gif)

After
---------------------------------
![video2gif_20181216_111732](https://user-images.githubusercontent.com/38397893/50052557-36b92880-0126-11e9-8c77-32f8dc5cefbb.gif)
